### PR TITLE
ignore Paket.Restore.targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,7 @@ ModelManifest.xml
 
 # Paket dependency manager
 .paket/paket.exe
+.paket/Paket.Restore.targets
 
 # FAKE - F# Make
 .fake/


### PR DESCRIPTION
Newer paket versions seem to create a `.paket/Paket.Restore.targets` file, which should be ignored.