### PR TITLE
ignore paket-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ ModelManifest.xml
 # Paket dependency manager
 .paket/paket.exe
 .paket/Paket.Restore.targets
+paket-files
 
 # FAKE - F# Make
 .fake/


### PR DESCRIPTION
The paket-files folder slipped through and should be part of the `.gitingore`.