### PR TITLE
let the type format itself

### DIFF
--- a/src/FSCS-Lensgenerator/FSCS-Lensgenerator.fsproj
+++ b/src/FSCS-Lensgenerator/FSCS-Lensgenerator.fsproj
@@ -24,6 +24,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <OtherFlags>--warnon:1182</OtherFlags>
+    <StartArguments>--projectname "SampleInput" --projectdir "C:\git\FSCS-LensgeneratorSample\SampleInput\SampleInput" --projectfilename "C:\git\FSCS-LensgeneratorSample\SampleInput\SampleInput\SampleInput.fsproj" --outputnamespace "SampleInput.Lenses" --outputdir "C:\git\_temp\SampleInput.Lenses" --syslib "System.Numerics" --shimreferenceassemblies</StartArguments>
+    <StartWorkingDirectory>C:\git\_temp\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSCS-Lensgenerator/LensGenerator.fs
+++ b/src/FSCS-Lensgenerator/LensGenerator.fs
@@ -337,10 +337,15 @@ module LensHelper = // I know...
                     e.GenericArguments
                     |> Seq.map getTypeDisplayName
                 )
+            let getFunctionCode (e:FSharpType) =
+                e.Format FSharpDisplayContext.Empty
             if t.IsTupleType then
                 getTupleCode t
             else
-                breakAndReturn "alternatives????" // todo: handle
+                if t.IsFunctionType then
+                    getFunctionCode t
+                else
+                    breakAndReturn "alternatives????" // todo: handle
 
     let getCandidatesForPropertyShorty (propName:string) (propTypeName:string) = 
         let bestPropName = bestname propName // current implementation


### PR DESCRIPTION
Tested with FSCS-LensgeneratorSample SampleInput project and it actually worked.

    let CreateErrorWriter_ : Lens<SampleInput.OutputConfig,Microsoft.FSharp.Core.unit -> System.IO.TextWriter> =
        let getterDef = ( fun (c:SampleInput.OutputConfig) -> c.CreateErrorWriter )
        let setterDef = ( fun (w:Microsoft.FSharp.Core.unit -> System.IO.TextWriter) (c:SampleInput.OutputConfig) -> {c with CreateErrorWriter = w } )
        (getterDef,setterDef)

 `e.Format FSharpDisplayContext.Empty` could solve other problems as well 😃 

should solve https://github.com/questnet/FSCS-Lensgenerator/issues/9